### PR TITLE
fix: Remove type from event sources to properly serialize/deserialize objects

### DIFF
--- a/Box.V2.Test/BoxEventsManagerTest.cs
+++ b/Box.V2.Test/BoxEventsManagerTest.cs
@@ -70,7 +70,7 @@ namespace Box.V2.Test
         [TestMethod]
         public async Task GetUserEventsFile_ValidResponse()
         {
-            var responseString = "{\"chunk_size\": 1, \"next_stream_position\": 123, \"entries\": [{\"source\":{\"file_id\":\"283257336425\",\"file_name\":\"ScreenShot2018-03-12at5.44.00PM.png\",\"user_id\":\"285663442\",\"user_name\":\"foo\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"}},\"created_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"},\"created_at\":\"2018-03-16T15:12:52-07:00\",\"event_id\":\"85c57bf3-bc15-4d24-93bc-955c796217c8\",\"event_type\":\"COLLABORATION_INVITE\",\"ip_address\":\"UnknownIP\",\"type\":\"event\",\"session_id\":null,\"additional_details\":null}]}";
+            var responseString = "{\"chunk_size\": 1, \"next_stream_position\": 123, \"entries\": [{\"source\":{\"file_id\":\"283257336425\",\"file_name\":\"ScreenShot2018-03-12at5.44.00PM.png\",\"user_id\":\"285663442\",\"user_name\":\"foo\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"},\"owned_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"}},\"created_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"},\"created_at\":\"2018-03-16T15:12:52-07:00\",\"event_id\":\"85c57bf3-bc15-4d24-93bc-955c796217c8\",\"event_type\":\"COLLABORATION_INVITE\",\"ip_address\":\"UnknownIP\",\"type\":\"event\",\"session_id\":null,\"additional_details\":null}]}";
             IBoxRequest boxRequest = null;
             Handler.Setup(h => h.ExecuteAsync<BoxEventCollection<BoxEnterpriseEvent>>(It.IsAny<IBoxRequest>()))
                 .Returns(Task.FromResult<IBoxResponse<BoxEventCollection<BoxEnterpriseEvent>>>(new BoxResponse<BoxEventCollection<BoxEnterpriseEvent>>()
@@ -88,12 +88,13 @@ namespace Box.V2.Test
             Assert.AreEqual(userFileEvents.Entries[0].Source.GetType(), typeof(BoxUserFileCollaborationEventSource));
             Assert.AreEqual(userFileEventSource.Id, "283257336425");
             Assert.AreEqual(userFileEventSource.Name, "ScreenShot2018-03-12at5.44.00PM.png");
+            Assert.AreEqual(userFileEventSource.OwnedBy.Id, "11111");
         }
 
         [TestMethod]
         public async Task GetUserEventsFolder_ValidResponse()
         {
-            var responseString = "{\"chunk_size\": 1, \"next_stream_position\": 123, \"entries\": [{\"source\":{\"folder_id\":\"47846340014\",\"folder_name\":\"SharedWithServiceAccount\",\"user_id\":\"182069272\",\"user_name\":\"MattWiller\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"}},\"created_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"},\"created_at\":\"2018-03-16T15:12:52-07:00\",\"event_id\":\"85c57bf3-bc15-4d24-93bc-955c796217c8\",\"event_type\":\"COLLABORATION_INVITE\",\"ip_address\":\"UnknownIP\",\"type\":\"event\",\"session_id\":null,\"additional_details\":null}]}";
+            var responseString = "{\"chunk_size\": 1, \"next_stream_position\": 123, \"entries\": [{\"source\":{\"folder_id\":\"47846340014\",\"folder_name\":\"SharedWithServiceAccount\",\"user_id\":\"182069272\",\"user_name\":\"MattWiller\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"},\"owned_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"}},\"created_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"},\"created_at\":\"2018-03-16T15:12:52-07:00\",\"event_id\":\"85c57bf3-bc15-4d24-93bc-955c796217c8\",\"event_type\":\"COLLABORATION_INVITE\",\"ip_address\":\"UnknownIP\",\"type\":\"event\",\"session_id\":null,\"additional_details\":null}]}";
             IBoxRequest boxRequest = null;
             Handler.Setup(h => h.ExecuteAsync<BoxEventCollection<BoxEnterpriseEvent>>(It.IsAny<IBoxRequest>()))
                 .Returns(Task.FromResult<IBoxResponse<BoxEventCollection<BoxEnterpriseEvent>>>(new BoxResponse<BoxEventCollection<BoxEnterpriseEvent>>()
@@ -111,12 +112,13 @@ namespace Box.V2.Test
             Assert.AreEqual(userFolderEvents.Entries[0].Source.GetType(), typeof(BoxUserFolderCollaborationEventSource));
             Assert.AreEqual(userFolderEventSource.Id, "47846340014");
             Assert.AreEqual(userFolderEventSource.Name, "SharedWithServiceAccount");
+            Assert.AreEqual(userFolderEventSource.OwnedBy.Id, "11111");
         }
 
         [TestMethod]
         public async Task GetGroupEventsFolder_ValidResponse()
         {
-            var responseString = "{\"chunk_size\": 1, \"next_stream_position\": 123, \"entries\": [{\"source\":{\"folder_id\":\"47846340014\",\"folder_name\":\"SharedWithServiceAccount\",\"group_id\":\"182069272\",\"group_name\":\"TestGroup\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"}},\"created_by\":{\"type\":\"user\",\"id\":\"275035869\",\"name\":\"MattWiller\",\"login\":\"mwiller + appusers@box.com\"},\"created_at\":\"2018-03-16T15:12:52-07:00\",\"event_id\":\"85c57bf3-bc15-4d24-93bc-955c796217c8\",\"event_type\":\"COLLABORATION_INVITE\",\"ip_address\":\"UnknownIP\",\"type\":\"event\",\"session_id\":null,\"additional_details\":null}]}";
+            var responseString = "{\"chunk_size\": 1, \"next_stream_position\": 123, \"entries\": [{\"source\":{\"folder_id\":\"47846340014\",\"folder_name\":\"SharedWithServiceAccount\",\"group_id\":\"182069272\",\"group_name\":\"TestGroup\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"},\"owned_by\":{\"type\":\"user\",\"id\":\"275035869\",\"name\":\"MattWiller\",\"login\":\"mwiller + appusers@box.com\"}},\"created_by\":{\"type\":\"user\",\"id\":\"275035869\",\"name\":\"MattWiller\",\"login\":\"mwiller + appusers@box.com\"},\"created_at\":\"2018-03-16T15:12:52-07:00\",\"event_id\":\"85c57bf3-bc15-4d24-93bc-955c796217c8\",\"event_type\":\"COLLABORATION_INVITE\",\"ip_address\":\"UnknownIP\",\"type\":\"event\",\"session_id\":null,\"additional_details\":null}]}";
             IBoxRequest boxRequest = null;
             Handler.Setup(h => h.ExecuteAsync<BoxEventCollection<BoxEnterpriseEvent>>(It.IsAny<IBoxRequest>()))
                 .Returns(Task.FromResult<IBoxResponse<BoxEventCollection<BoxEnterpriseEvent>>>(new BoxResponse<BoxEventCollection<BoxEnterpriseEvent>>()
@@ -134,12 +136,13 @@ namespace Box.V2.Test
             Assert.AreEqual(groupFolderEvents.Entries[0].Source.GetType(), typeof(BoxGroupFolderCollaborationEventSource));
             Assert.AreEqual(groupFolderEventSource.Id, "47846340014");
             Assert.AreEqual(groupFolderEventSource.GroupName, "TestGroup");
+            Assert.AreEqual(groupFolderEventSource.OwnedBy.Id, "275035869");
         }
 
         [TestMethod]
         public async Task GetGroupEventsFile_ValidResponse()
         {
-            var responseString = "{\"chunk_size\": 1, \"next_stream_position\": 123, \"entries\": [{\"source\":{\"file_id\":\"47846340014\",\"file_name\":\"test-picture.jpg\",\"group_id\":\"182069272\",\"group_name\":\"TestGroup\"},\"created_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"},\"created_at\":\"2018-03-16T15:12:52-07:00\",\"event_id\":\"85c57bf3-bc15-4d24-93bc-955c796217c8\",\"event_type\":\"COLLABORATION_INVITE\",\"ip_address\":\"UnknownIP\",\"type\":\"event\",\"session_id\":null,\"additional_details\":null}]}";
+            var responseString = "{\"chunk_size\": 1, \"next_stream_position\": 123, \"entries\": [{\"source\":{\"file_id\":\"47846340014\",\"file_name\":\"test-picture.jpg\",\"group_id\":\"182069272\",\"group_name\":\"TestGroup\",\"owned_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"}},\"created_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"},\"created_at\":\"2018-03-16T15:12:52-07:00\",\"event_id\":\"85c57bf3-bc15-4d24-93bc-955c796217c8\",\"event_type\":\"COLLABORATION_INVITE\",\"ip_address\":\"UnknownIP\",\"type\":\"event\",\"session_id\":null,\"additional_details\":null}]}";
             IBoxRequest boxRequest = null;
             Handler.Setup(h => h.ExecuteAsync<BoxEventCollection<BoxEnterpriseEvent>>(It.IsAny<IBoxRequest>()))
                 .Returns(Task.FromResult<IBoxResponse<BoxEventCollection<BoxEnterpriseEvent>>>(new BoxResponse<BoxEventCollection<BoxEnterpriseEvent>>()
@@ -157,6 +160,7 @@ namespace Box.V2.Test
             Assert.AreEqual(groupFileEvents.Entries[0].Source.GetType(), typeof(BoxGroupFileCollaborationEventSource));
             Assert.AreEqual(groupFileEventSource.Id, "47846340014");
             Assert.AreEqual(groupFileEventSource.Name, "test-picture.jpg");
+            Assert.AreEqual(groupFileEventSource.OwnedBy.Id, "11111");
         }
 
         [TestMethod]

--- a/Box.V2.Test/BoxEventsManagerTest.cs
+++ b/Box.V2.Test/BoxEventsManagerTest.cs
@@ -92,6 +92,30 @@ namespace Box.V2.Test
         }
 
         [TestMethod]
+        public async Task GetUserEventsFile_ExternalUser_ValidResponse()
+        {
+            var responseString = "{\"chunk_size\": 1, \"next_stream_position\": 123, \"entries\": [{\"source\":{\"file_id\":\"283257336425\",\"file_name\":\"ScreenShot2018-03-12at5.44.00PM.png\",\"user_email\": \"external.user@box.com\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"},\"owned_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"}},\"created_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"},\"created_at\":\"2018-03-16T15:12:52-07:00\",\"event_id\":\"85c57bf3-bc15-4d24-93bc-955c796217c8\",\"event_type\":\"COLLABORATION_INVITE\",\"ip_address\":\"UnknownIP\",\"type\":\"event\",\"session_id\":null,\"additional_details\":null}]}";
+            IBoxRequest boxRequest = null;
+            Handler.Setup(h => h.ExecuteAsync<BoxEventCollection<BoxEnterpriseEvent>>(It.IsAny<IBoxRequest>()))
+                .Returns(Task.FromResult<IBoxResponse<BoxEventCollection<BoxEnterpriseEvent>>>(new BoxResponse<BoxEventCollection<BoxEnterpriseEvent>>()
+                {
+                    Status = ResponseStatus.Success,
+                    ContentString = responseString
+                })).Callback<IBoxRequest>(r => boxRequest = r);
+
+            /*** Act ***/
+            var userFileEvents = await _eventsManager.EnterpriseEventsAsync();
+
+            var externalUserFileCollaborationEventSource = userFileEvents.Entries[0].Source as BoxExternalUserFileCollaborationEventSource;
+
+            Assert.AreEqual(userFileEvents.Entries[0].EventType, "COLLABORATION_INVITE");
+            Assert.AreEqual(userFileEvents.Entries[0].Source.GetType(), typeof(BoxExternalUserFileCollaborationEventSource));
+            Assert.AreEqual(externalUserFileCollaborationEventSource.Id, "283257336425");
+            Assert.AreEqual(externalUserFileCollaborationEventSource.Name, "ScreenShot2018-03-12at5.44.00PM.png");
+            Assert.AreEqual(externalUserFileCollaborationEventSource.OwnedBy.Id, "11111");
+        }
+
+        [TestMethod]
         public async Task GetUserEventsFolder_ValidResponse()
         {
             var responseString = "{\"chunk_size\": 1, \"next_stream_position\": 123, \"entries\": [{\"source\":{\"folder_id\":\"47846340014\",\"folder_name\":\"SharedWithServiceAccount\",\"user_id\":\"182069272\",\"user_name\":\"MattWiller\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"},\"owned_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"}},\"created_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"},\"created_at\":\"2018-03-16T15:12:52-07:00\",\"event_id\":\"85c57bf3-bc15-4d24-93bc-955c796217c8\",\"event_type\":\"COLLABORATION_INVITE\",\"ip_address\":\"UnknownIP\",\"type\":\"event\",\"session_id\":null,\"additional_details\":null}]}";
@@ -110,6 +134,30 @@ namespace Box.V2.Test
 
             Assert.AreEqual(userFolderEvents.Entries[0].EventType, "COLLABORATION_INVITE");
             Assert.AreEqual(userFolderEvents.Entries[0].Source.GetType(), typeof(BoxUserFolderCollaborationEventSource));
+            Assert.AreEqual(userFolderEventSource.Id, "47846340014");
+            Assert.AreEqual(userFolderEventSource.Name, "SharedWithServiceAccount");
+            Assert.AreEqual(userFolderEventSource.OwnedBy.Id, "11111");
+        }
+
+        [TestMethod]
+        public async Task GetUserEventsFolder_ExternalUser_ValidResponse()
+        {
+            var responseString = "{\"chunk_size\": 1, \"next_stream_position\": 123, \"entries\": [{\"source\":{\"folder_id\":\"47846340014\",\"folder_name\":\"SharedWithServiceAccount\",\"user_email\": \"external.user@box.com\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"},\"owned_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"}},\"created_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"},\"created_at\":\"2018-03-16T15:12:52-07:00\",\"event_id\":\"85c57bf3-bc15-4d24-93bc-955c796217c8\",\"event_type\":\"COLLABORATION_INVITE\",\"ip_address\":\"UnknownIP\",\"type\":\"event\",\"session_id\":null,\"additional_details\":null}]}";
+            IBoxRequest boxRequest = null;
+            Handler.Setup(h => h.ExecuteAsync<BoxEventCollection<BoxEnterpriseEvent>>(It.IsAny<IBoxRequest>()))
+                .Returns(Task.FromResult<IBoxResponse<BoxEventCollection<BoxEnterpriseEvent>>>(new BoxResponse<BoxEventCollection<BoxEnterpriseEvent>>()
+                {
+                    Status = ResponseStatus.Success,
+                    ContentString = responseString
+                })).Callback<IBoxRequest>(r => boxRequest = r);
+
+            /*** Act ***/
+            var userFolderEvents = await _eventsManager.EnterpriseEventsAsync();
+
+            var userFolderEventSource = userFolderEvents.Entries[0].Source as BoxExternalUserFolderCollaborationEventSource;
+
+            Assert.AreEqual(userFolderEvents.Entries[0].EventType, "COLLABORATION_INVITE");
+            Assert.AreEqual(userFolderEvents.Entries[0].Source.GetType(), typeof(BoxExternalUserFolderCollaborationEventSource));
             Assert.AreEqual(userFolderEventSource.Id, "47846340014");
             Assert.AreEqual(userFolderEventSource.Name, "SharedWithServiceAccount");
             Assert.AreEqual(userFolderEventSource.OwnedBy.Id, "11111");

--- a/Box.V2.Test/Converters/BoxJsonConverterTest.cs
+++ b/Box.V2.Test/Converters/BoxJsonConverterTest.cs
@@ -1,0 +1,150 @@
+using Box.V2.Converter;
+using Box.V2.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Box.V2.Test
+{
+    [TestClass]
+    public class BoxJsonConverterTest : BoxResourceManagerTest
+    {
+        private readonly IBoxConverter _converter;
+
+        public BoxJsonConverterTest()
+        {
+            _converter = new BoxJsonConverter();
+        }
+
+        [TestMethod]
+        public void BoxUserFileCollaborationEventSource_ValidateConversion()
+        {
+            var sourceString = "{\"file_id\":\"283257336425\",\"file_name\":\"ScreenShot2018-03-12at5.44.00PM.png\",\"user_id\":\"285663442\",\"user_name\":\"foo\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"},\"owned_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"}}";
+            var sourceObject = _converter.Parse<BoxUserFileCollaborationEventSource>(sourceString);
+
+            var serializedObjectString = _converter.Serialize(sourceObject);
+
+            var boxUserFileCollaborationEventSource = _converter.Parse<BoxUserFileCollaborationEventSource>(serializedObjectString);
+
+            Assert.AreEqual(boxUserFileCollaborationEventSource.GetType(), typeof(BoxUserFileCollaborationEventSource));
+            Assert.IsNull(boxUserFileCollaborationEventSource.Type);
+            Assert.AreEqual(boxUserFileCollaborationEventSource.Id, "283257336425");
+            Assert.AreEqual(boxUserFileCollaborationEventSource.Name, "ScreenShot2018-03-12at5.44.00PM.png");
+            Assert.AreEqual(boxUserFileCollaborationEventSource.UserName, "foo");
+            Assert.AreEqual(boxUserFileCollaborationEventSource.OwnedBy.Id, "11111");
+            Assert.AreEqual(boxUserFileCollaborationEventSource.Parent.Id, "0");
+        }
+
+        [TestMethod]
+        public void BoxExternalUserFileCollaborationEventSource_ValidateConversion()
+        {
+            var sourceString = "{\"file_id\":\"283257336425\",\"file_name\":\"ScreenShot2018-03-12at5.44.00PM.png\",\"user_email\": \"external.user@box.com\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"},\"owned_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"}}";
+            var sourceObject = _converter.Parse<BoxExternalUserFileCollaborationEventSource>(sourceString);
+
+            var serializedObjectString = _converter.Serialize(sourceObject);
+
+            var boxExternalUserFileCollaborationEventSource = _converter.Parse<BoxExternalUserFileCollaborationEventSource>(serializedObjectString);
+
+            Assert.AreEqual(boxExternalUserFileCollaborationEventSource.GetType(), typeof(BoxExternalUserFileCollaborationEventSource));
+            Assert.IsNull(boxExternalUserFileCollaborationEventSource.Type);
+            Assert.AreEqual(boxExternalUserFileCollaborationEventSource.Id, "283257336425");
+            Assert.AreEqual(boxExternalUserFileCollaborationEventSource.Name, "ScreenShot2018-03-12at5.44.00PM.png");
+            Assert.AreEqual(boxExternalUserFileCollaborationEventSource.UserEmail, "external.user@box.com");
+            Assert.AreEqual(boxExternalUserFileCollaborationEventSource.OwnedBy.Id, "11111");
+            Assert.AreEqual(boxExternalUserFileCollaborationEventSource.Parent.Id, "0");
+        }
+
+        [TestMethod]
+        public void BoxUserFolderCollaborationEventSource_ValidateConversion()
+        {
+            var sourceString = "{\"folder_id\":\"47846340014\",\"folder_name\":\"SharedWithServiceAccount\",\"user_id\":\"182069272\",\"user_name\":\"MattWiller\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"},\"owned_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"}}";
+            var sourceObject = _converter.Parse<BoxUserFolderCollaborationEventSource>(sourceString);
+
+            var serializedObjectString = _converter.Serialize(sourceObject);
+
+            var boxUserFolderCollaborationEventSource = _converter.Parse<BoxUserFolderCollaborationEventSource>(serializedObjectString);
+
+            Assert.AreEqual(boxUserFolderCollaborationEventSource.GetType(), typeof(BoxUserFolderCollaborationEventSource));
+            Assert.IsNull(boxUserFolderCollaborationEventSource.Type);
+            Assert.AreEqual(boxUserFolderCollaborationEventSource.Id, "47846340014");
+            Assert.AreEqual(boxUserFolderCollaborationEventSource.UserId, "182069272");
+            Assert.AreEqual(boxUserFolderCollaborationEventSource.UserName, "MattWiller");
+            Assert.AreEqual(boxUserFolderCollaborationEventSource.Name, "SharedWithServiceAccount");
+            Assert.AreEqual(boxUserFolderCollaborationEventSource.OwnedBy.Id, "11111");
+            Assert.AreEqual(boxUserFolderCollaborationEventSource.Parent.Id, "0");
+        }
+
+        [TestMethod]
+        public void BoxExternalUserFolderCollaborationEventSource_ValidateConversion()
+        {
+            var sourceString = "{\"folder_id\":\"47846340014\",\"folder_name\":\"SharedWithServiceAccount\",\"user_email\": \"external.user@box.com\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"},\"owned_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"}}";
+            var sourceObject = _converter.Parse<BoxExternalUserFolderCollaborationEventSource>(sourceString);
+
+            var serializedObjectString = _converter.Serialize(sourceObject);
+
+            var externalUserFolderEventSource = _converter.Parse<BoxExternalUserFolderCollaborationEventSource>(serializedObjectString);
+
+            Assert.AreEqual(externalUserFolderEventSource.GetType(), typeof(BoxExternalUserFolderCollaborationEventSource));
+            Assert.IsNull(externalUserFolderEventSource.Type);
+            Assert.AreEqual(externalUserFolderEventSource.Id, "47846340014");
+            Assert.AreEqual(externalUserFolderEventSource.Name, "SharedWithServiceAccount");
+            Assert.AreEqual(externalUserFolderEventSource.UserEmail, "external.user@box.com");
+            Assert.AreEqual(externalUserFolderEventSource.Parent.Id, "0");
+            Assert.AreEqual(externalUserFolderEventSource.OwnedBy.Id, "11111");
+        }
+
+        [TestMethod]
+        public void BoxGroupFolderCollaborationEventSource_ValidateConversion()
+        {
+            var sourceString = "{\"folder_id\":\"47846340014\",\"folder_name\":\"SharedWithServiceAccount\",\"group_id\":\"182069272\",\"group_name\":\"TestGroup\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"},\"owned_by\":{\"type\":\"user\",\"id\":\"275035869\",\"name\":\"MattWiller\",\"login\":\"mwiller + appusers@box.com\"}}";
+            var sourceObject = _converter.Parse<BoxGroupFolderCollaborationEventSource>(sourceString);
+
+            var serializedObjectString = _converter.Serialize(sourceObject);
+
+            var boxGroupFolderCollaborationEventSource = _converter.Parse<BoxGroupFolderCollaborationEventSource>(serializedObjectString);
+
+            Assert.AreEqual(boxGroupFolderCollaborationEventSource.GetType(), typeof(BoxGroupFolderCollaborationEventSource));
+            Assert.IsNull(boxGroupFolderCollaborationEventSource.Type);
+            Assert.AreEqual(boxGroupFolderCollaborationEventSource.Id, "47846340014");
+            Assert.AreEqual(boxGroupFolderCollaborationEventSource.Name, "SharedWithServiceAccount");
+            Assert.AreEqual(boxGroupFolderCollaborationEventSource.GroupId, "182069272");
+            Assert.AreEqual(boxGroupFolderCollaborationEventSource.GroupName, "TestGroup");
+            Assert.AreEqual(boxGroupFolderCollaborationEventSource.Parent.Id, "0");
+            Assert.AreEqual(boxGroupFolderCollaborationEventSource.OwnedBy.Id, "275035869");
+        }
+
+        [TestMethod]
+        public void BoxGroupFileCollaborationEventSource_ValidateConversion()
+        {
+            var sourceString = "{\"file_id\":\"47846340014\",\"file_name\":\"test-picture.jpg\",\"group_id\":\"182069272\",\"group_name\":\"TestGroup\",\"parent\":{\"type\":\"folder\",\"name\":\"AllFiles\",\"id\":\"0\"},\"owned_by\":{\"type\":\"user\",\"id\":\"11111\",\"name\":\"Test User\",\"login\":\"test@user.com\"}}";
+            var sourceObject = _converter.Parse<BoxGroupFileCollaborationEventSource>(sourceString);
+
+            var serializedObjectString = _converter.Serialize(sourceObject);
+
+            var boxGroupFileCollaborationEventSource = _converter.Parse<BoxGroupFileCollaborationEventSource>(serializedObjectString);
+
+            Assert.AreEqual(boxGroupFileCollaborationEventSource.GetType(), typeof(BoxGroupFileCollaborationEventSource));
+            Assert.IsNull(boxGroupFileCollaborationEventSource.Type);
+            Assert.AreEqual(boxGroupFileCollaborationEventSource.Id, "47846340014");
+            Assert.AreEqual(boxGroupFileCollaborationEventSource.Name, "test-picture.jpg");
+            Assert.AreEqual(boxGroupFileCollaborationEventSource.GroupId, "182069272");
+            Assert.AreEqual(boxGroupFileCollaborationEventSource.GroupName, "TestGroup");
+            Assert.AreEqual(boxGroupFileCollaborationEventSource.Parent.Id, "0");
+            Assert.AreEqual(boxGroupFileCollaborationEventSource.OwnedBy.Id, "11111");
+        }
+
+        [TestMethod]
+        public void BoxGroupEventSource_ValidateConversion()
+        {
+            var sourceString = "{\"group_id\": \"182069272\",\"group_name\": \"TestGroup\"}";
+            var sourceObject = _converter.Parse<BoxGroupEventSource>(sourceString);
+
+            var serializedObjectString = _converter.Serialize(sourceObject);
+
+            var boxGroupEventSource = _converter.Parse<BoxGroupEventSource>(serializedObjectString);
+
+            Assert.AreEqual(boxGroupEventSource.GetType(), typeof(BoxGroupEventSource));
+            Assert.IsNull(boxGroupEventSource.Type);
+            Assert.AreEqual(boxGroupEventSource.Id, "182069272");
+            Assert.AreEqual(boxGroupEventSource.Name, "TestGroup");
+        }
+    }
+}

--- a/Box.V2/Box.V2.csproj
+++ b/Box.V2/Box.V2.csproj
@@ -144,6 +144,8 @@
     <Compile Include="Models\BoxEmailAlias.cs" />
     <Compile Include="Models\BoxEnterprise.cs" />
     <Compile Include="Models\BoxEnterpriseEvent.cs" />
+    <Compile Include="Models\BoxExternalUserFileCollaborationEventSource.cs" />
+    <Compile Include="Models\BoxExternalUserFolderCollaborationEventSource.cs" />
     <Compile Include="Models\BoxFileRequestObject.cs" />
     <Compile Include="Models\BoxFolderEventSource.cs" />
     <Compile Include="Models\BoxFolderLock.cs" />

--- a/Box.V2/Converter/BoxItemConverter.cs
+++ b/Box.V2/Converter/BoxItemConverter.cs
@@ -14,6 +14,7 @@ namespace Box.V2.Converter
         private const string WatermarkType = "watermark";
         private const string GroupId = "group_id";
         private const string UserId = "user_id";
+        private const string UserEmail = "user_email";
         private const string FolderId = "folder_id";
         private const string FileId = "file_id";
 
@@ -124,14 +125,13 @@ namespace Box.V2.Converter
                 {
                     return new BoxGroupFolderCollaborationEventSource();
                 }
-                else if (FieldExists(FileId, jObject))
+
+                if (FieldExists(FileId, jObject))
                 {
                     return new BoxGroupFileCollaborationEventSource();
                 }
-                else
-                {
-                    return new BoxGroupEventSource();
-                }
+
+                return new BoxGroupEventSource();
             }
             else if (FieldExists(UserId, jObject) && FieldExists(FileId, jObject))
             {
@@ -140,6 +140,14 @@ namespace Box.V2.Converter
             else if (FieldExists(UserId, jObject) && FieldExists(FolderId, jObject))
             {
                 return new BoxUserFolderCollaborationEventSource();
+            }
+            else if (FieldExists(UserEmail, jObject) && FieldExists(FileId, jObject))
+            {
+                return new BoxExternalUserFileCollaborationEventSource();
+            }
+            else if (FieldExists(UserEmail, jObject) && FieldExists(FolderId, jObject))
+            {
+                return new BoxExternalUserFolderCollaborationEventSource();
             }
 
             return new BoxEntity();
@@ -174,7 +182,7 @@ namespace Box.V2.Converter
 
             // Load JObject from stream
             var jObject = JObject.Load(reader);
-            // The notification_email field for the user object is an object when a value exists and is an empty array when it isn't. The code below converts the empty array to a null value to avoid deserialization issues.  
+            // The notification_email field for the user object is an object when a value exists and is an empty array when it isn't. The code below converts the empty array to a null value to avoid deserialization issues.
             if (jObject["type"] != null && jObject["type"].ToString() == "user" && jObject["notification_email"] != null && jObject["notification_email"].Type == JTokenType.Array)
             {
                 jObject["notification_email"] = null;

--- a/Box.V2/Models/BoxExternalUserFileCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxExternalUserFileCollaborationEventSource.cs
@@ -17,11 +17,6 @@ namespace Box.V2.Models
         public override string Id { get; protected set; }
 
         /// <summary>
-        /// The type of the object.
-        /// </summary>
-        public override string Type { get { return "file"; } protected set { return; } }
-
-        /// <summary>
         /// The name of the file being collaborated on.
         /// </summary>
         [JsonProperty(PropertyName = FieldFileName)]

--- a/Box.V2/Models/BoxExternalUserFileCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxExternalUserFileCollaborationEventSource.cs
@@ -1,0 +1,48 @@
+using Newtonsoft.Json;
+
+namespace Box.V2.Models
+{
+    public class BoxExternalUserFileCollaborationEventSource : BoxEntity
+    {
+        public const string FieldFileId = "file_id";
+        public const string FieldFileName = "file_name";
+        public const string FieldUserEmail = "user_email";
+        public const string FieldParent = "parent";
+        public const string FieldOwnedBy = "owned_by";
+
+        /// <summary>
+        /// The unique ID of the file being collaborated on.
+        /// </summary>
+        [JsonProperty(PropertyName = FieldFileId)]
+        public override string Id { get; protected set; }
+
+        /// <summary>
+        /// The type of the object.
+        /// </summary>
+        public override string Type { get { return "file"; } protected set { return; } }
+
+        /// <summary>
+        /// The name of the file being collaborated on.
+        /// </summary>
+        [JsonProperty(PropertyName = FieldFileName)]
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// The email of the external user collaborating on the folder
+        /// </summary>
+        [JsonProperty(PropertyName = FieldUserEmail)]
+        public string UserEmail { get; private set; }
+
+        /// <summary>
+        /// The parent folder of the file being collaborated on.
+        /// </summary>
+        [JsonProperty(PropertyName = FieldParent)]
+        public BoxFolder Parent { get; private set; }
+
+        /// <summary>
+        /// The user that owns this file
+        /// </summary>
+        [JsonProperty(PropertyName = FieldOwnedBy)]
+        public BoxUser OwnedBy { get; private set; }
+    }
+}

--- a/Box.V2/Models/BoxExternalUserFolderCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxExternalUserFolderCollaborationEventSource.cs
@@ -1,0 +1,48 @@
+using Newtonsoft.Json;
+
+namespace Box.V2.Models
+{
+    public class BoxExternalUserFolderCollaborationEventSource : BoxEntity
+    {
+        public const string FieldFolderId = "folder_id";
+        public const string FieldFolderName = "folder_name";
+        public const string FieldUserEmail = "user_email";
+        public const string FieldParent = "parent";
+        public const string FieldOwnedBy = "owned_by";
+
+        /// <summary>
+        /// The unique ID of the folder being collaborated on.
+        /// </summary>
+        [JsonProperty(PropertyName = FieldFolderId)]
+        public override string Id { get; protected set; }
+
+        /// <summary>
+        /// The type of the object.
+        /// </summary>
+        public override string Type { get { return "folder"; } protected set { return; } }
+
+        /// <summary>
+        /// The name of the folder being collaborated on.
+        /// </summary>
+        [JsonProperty(PropertyName = FieldFolderName)]
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// The email of the external user collaborating on the folder
+        /// </summary>
+        [JsonProperty(PropertyName = FieldUserEmail)]
+        public string UserEmail { get; private set; }
+
+        /// <summary>
+        /// The parent folder of the folder being collaborated on.
+        /// </summary>
+        [JsonProperty(PropertyName = FieldParent)]
+        public BoxFolder Parent { get; private set; }
+
+        /// <summary>
+        /// The user that owns this folder
+        /// </summary>
+        [JsonProperty(PropertyName = FieldOwnedBy)]
+        public BoxUser OwnedBy { get; private set; }
+    }
+}

--- a/Box.V2/Models/BoxExternalUserFolderCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxExternalUserFolderCollaborationEventSource.cs
@@ -17,11 +17,6 @@ namespace Box.V2.Models
         public override string Id { get; protected set; }
 
         /// <summary>
-        /// The type of the object.
-        /// </summary>
-        public override string Type { get { return "folder"; } protected set { return; } }
-
-        /// <summary>
         /// The name of the folder being collaborated on.
         /// </summary>
         [JsonProperty(PropertyName = FieldFolderName)]

--- a/Box.V2/Models/BoxFileEventSource.cs
+++ b/Box.V2/Models/BoxFileEventSource.cs
@@ -11,6 +11,7 @@ namespace Box.V2.Models
         public const string FieldItemId = "item_id";
         public const string FieldItemName = "item_name";
         public const string FieldItemParent = "parent";
+        public const string FieldOwnedBy = "owned_by";
 
         /// <summary>
         /// The type of the event source
@@ -35,5 +36,11 @@ namespace Box.V2.Models
         /// </summary>
         [JsonProperty(PropertyName = FieldItemParent)]
         public BoxFolder Parent { get; private set; }
+
+        /// <summary>
+        /// The user that owns this file
+        /// </summary>
+        [JsonProperty(PropertyName = FieldOwnedBy)]
+        public BoxUser OwnedBy { get; private set; }
     }
 }

--- a/Box.V2/Models/BoxFolderEventSource.cs
+++ b/Box.V2/Models/BoxFolderEventSource.cs
@@ -11,6 +11,7 @@ namespace Box.V2.Models
         public const string FieldItemId = "item_id";
         public const string FieldItemName = "item_name";
         public const string FieldItemParent = "parent";
+        public const string FieldOwnedBy = "owned_by";
 
         /// <summary>
         /// The type of the event source
@@ -35,5 +36,11 @@ namespace Box.V2.Models
         /// </summary>
         [JsonProperty(PropertyName = FieldItemParent)]
         public BoxFolder Parent { get; private set; }
+
+        /// <summary>
+        /// The user that owns this folder
+        /// </summary>
+        [JsonProperty(PropertyName = FieldOwnedBy)]
+        public BoxUser OwnedBy { get; private set; }
     }
 }

--- a/Box.V2/Models/BoxGroupEventSource.cs
+++ b/Box.V2/Models/BoxGroupEventSource.cs
@@ -17,12 +17,7 @@ namespace Box.V2.Models
         public override string Id { get; protected set; }
 
         /// <summary>
-        /// The type of the object.
-        /// </summary>
-        public override string Type { get { return "group"; } protected set { return; } }
-
-        /// <summary>
-        /// The name of the group resource. 
+        /// The name of the group resource.
         /// </summary>
         [JsonProperty(PropertyName = FieldGroupName)]
         public string Name { get; private set; }

--- a/Box.V2/Models/BoxGroupFileCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxGroupFileCollaborationEventSource.cs
@@ -9,6 +9,7 @@ namespace Box.V2.Models
         public const string FieldGroupId = "group_id";
         public const string FieldGroupName = "group_name";
         public const string FieldParent = "parent";
+        public const string FieldOwnedBy = "owned_by";
 
         /// <summary>
         /// The unique ID of the file being collaborated on.
@@ -44,5 +45,11 @@ namespace Box.V2.Models
         /// </summary>
         [JsonProperty(PropertyName = FieldParent)]
         public BoxFolder Parent { get; private set; }
+
+        /// <summary>
+        /// The user that owns this file
+        /// </summary>
+        [JsonProperty(PropertyName = FieldOwnedBy)]
+        public BoxUser OwnedBy { get; private set; }
     }
 }

--- a/Box.V2/Models/BoxGroupFileCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxGroupFileCollaborationEventSource.cs
@@ -18,11 +18,6 @@ namespace Box.V2.Models
         public override string Id { get; protected set; }
 
         /// <summary>
-        /// The type of the object.
-        /// </summary>
-        public override string Type { get { return "file"; } protected set { return; } }
-
-        /// <summary>
         /// The name of the file being collaborated on.
         /// </summary>
         [JsonProperty(PropertyName = FieldFileName)]

--- a/Box.V2/Models/BoxGroupFolderCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxGroupFolderCollaborationEventSource.cs
@@ -18,11 +18,6 @@ namespace Box.V2.Models
         public override string Id { get; protected set; }
 
         /// <summary>
-        /// The type of the object.
-        /// </summary>
-        public override string Type { get { return "folder"; } protected set { return; } }
-
-        /// <summary>
         /// The name of the folder being collaborated on.
         /// </summary>
         [JsonProperty(PropertyName = FieldFolderName)]

--- a/Box.V2/Models/BoxGroupFolderCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxGroupFolderCollaborationEventSource.cs
@@ -9,6 +9,7 @@ namespace Box.V2.Models
         public const string FieldGroupId = "group_id";
         public const string FieldGroupName = "group_name";
         public const string FieldParent = "parent";
+        public const string FieldOwnedBy = "owned_by";
 
         /// <summary>
         /// The unique ID of the folder being collaborated on.
@@ -44,5 +45,11 @@ namespace Box.V2.Models
         /// </summary>
         [JsonProperty(PropertyName = FieldParent)]
         public BoxFolder Parent { get; private set; }
+
+        /// <summary>
+        /// The user that owns this folder
+        /// </summary>
+        [JsonProperty(PropertyName = FieldOwnedBy)]
+        public BoxUser OwnedBy { get; private set; }
     }
 }

--- a/Box.V2/Models/BoxUserFileCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxUserFileCollaborationEventSource.cs
@@ -9,6 +9,7 @@ namespace Box.V2.Models
         public const string FieldUserId = "user_id";
         public const string FieldUserName = "user_name";
         public const string FieldParent = "parent";
+        public const string FieldOwnedBy = "owned_by";
 
         /// <summary>
         /// The unique ID of the file being collaborated on.
@@ -44,5 +45,11 @@ namespace Box.V2.Models
         /// </summary>
         [JsonProperty(PropertyName = FieldParent)]
         public BoxFolder Parent { get; private set; }
+
+        /// <summary>
+        /// The user that owns this file
+        /// </summary>
+        [JsonProperty(PropertyName = FieldOwnedBy)]
+        public BoxUser OwnedBy { get; private set; }
     }
 }

--- a/Box.V2/Models/BoxUserFileCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxUserFileCollaborationEventSource.cs
@@ -18,11 +18,6 @@ namespace Box.V2.Models
         public override string Id { get; protected set; }
 
         /// <summary>
-        /// The type of the object.
-        /// </summary>
-        public override string Type { get { return "file"; } protected set { return; } }
-
-        /// <summary>
         /// The name of the file being collaborated on.
         /// </summary>
         [JsonProperty(PropertyName = FieldFileName)]

--- a/Box.V2/Models/BoxUserFolderCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxUserFolderCollaborationEventSource.cs
@@ -12,6 +12,7 @@ namespace Box.V2.Models
         public const string FieldUserId = "user_id";
         public const string FieldUserName = "user_name";
         public const string FieldParent = "parent";
+        public const string FieldOwnedBy = "owned_by";
 
         /// <summary>
         /// The unique ID of the folder being collaborated on.
@@ -47,5 +48,11 @@ namespace Box.V2.Models
         /// </summary>
         [JsonProperty(PropertyName = FieldParent)]
         public BoxFolder Parent { get; private set; }
+
+        /// <summary>
+        /// The user that owns this folder
+        /// </summary>
+        [JsonProperty(PropertyName = FieldOwnedBy)]
+        public BoxUser OwnedBy { get; private set; }
     }
 }

--- a/Box.V2/Models/BoxUserFolderCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxUserFolderCollaborationEventSource.cs
@@ -21,11 +21,6 @@ namespace Box.V2.Models
         public override string Id { get; protected set; }
 
         /// <summary>
-        /// The type of the object.
-        /// </summary>
-        public override string Type { get { return "folder"; } protected set { return; } }
-
-        /// <summary>
         /// The name of the folder  being collaborated on.
         /// </summary>
         [JsonProperty(PropertyName = FieldFolderName)]


### PR DESCRIPTION
The type property doesn't exist on the event source objects on the enterprise events, so by adding it we actually end up breaking the converter logic as objects with type **file**, **folder** or **group** resolve to be a **BoxFile**, **BoxFolder** or **BoxGroup** instead of their correct event sources.